### PR TITLE
make wayland default

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,8 @@ LABEL build_version="Linuxserver.io version:- ${VERSION} Build-date:- ${BUILD_DA
 LABEL maintainer="thelamer"
 
 # title
-ENV TITLE=Dolphin
+ENV TITLE=Dolphin \
+    PIXELFLUX_WAYLAND=true
 
 RUN \
   echo "**** add icon ****" && \

--- a/Dockerfile.aarch64
+++ b/Dockerfile.aarch64
@@ -9,7 +9,8 @@ LABEL build_version="Linuxserver.io version:- ${VERSION} Build-date:- ${BUILD_DA
 LABEL maintainer="thelamer"
 
 # title
-ENV TITLE=Dolphin
+ENV TITLE=Dolphin \
+    PIXELFLUX_WAYLAND=true
 
 RUN \
   echo "**** add icon ****" && \

--- a/README.md
+++ b/README.md
@@ -612,6 +612,7 @@ Once registered you can define the dockerfile to use with `-f Dockerfile.aarch64
 
 ## Versions
 
+* **05.03.26:** - Make Wayland default disable with PIXELFLUX_WAYLAND=false.
 * **20.12.25:** - Add Wayland init logic.
 * **15.08.25:** - Rebase to Debian Trixie for updated Dolphin, update controller mapping.
 * **18.06.25:** - Initial Version.

--- a/readme-vars.yml
+++ b/readme-vars.yml
@@ -107,6 +107,7 @@ init_diagram: |
   "dolphin:latest" <- Base Images
 # changelog
 changelogs:
+  - {date: "05.03.26:", desc: "Make Wayland default disable with PIXELFLUX_WAYLAND=false."}
   - {date: "20.12.25:", desc: "Add Wayland init logic."}
   - {date: "15.08.25:", desc: "Rebase to Debian Trixie for updated Dolphin, update controller mapping."}
   - {date: "18.06.25:", desc: "Initial Version."}


### PR DESCRIPTION
This flags the image to run in Wayland mode by default.

Wayland has some oddities and external setup for Nvidia, but in general is a night and day difference for an accelerated session. 

I am starting with the series of gaming focused images where things like international keyboard or other bugs do not matter. This can be easily disabled as these repositories have existing X11 init logic you just flag it in the env to go back. 